### PR TITLE
Build install page

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %} - Orchestrates virtual Ubuntu instancess</title>
+    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %} - Orchestrates virtual Ubuntu instances</title>
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/cb22ba5d-favicon-16x16.png" sizes="16x16" />

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,0 +1,26 @@
+<header id="navigation" class="p-navigation">
+  <div class="row">
+    <div class="p-navigation__banner">
+      <div class="p-navigation__logo">
+        <a class="p-navigation__link" href="/">
+          <h4 class="p-navigation__image u-no-margin--bottom">Multipass</h4>
+        </a>
+      </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
+    </div>
+    <nav class="p-navigation__nav" role="menubar">
+      <span class="u-off-screen">
+        <a href="#main-content">Jump to main content</a>
+      </span>
+      <ul class="p-navigation__links" role="menu">
+        <li class="p-navigation__link {% if page.page == 'install' %}is-selected{% endif %}" role="menuitem">
+          <a href="/install">Install</a>
+        </li>
+        <li class="p-navigation__link" role="menuitem">
+          <a href="https://discourse.ubuntu.com/c/multipass" class="p-link--external">Discourse</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,11 +5,13 @@
 
 <body>
 
-    <div class="page-content">
-        {{ content }}
-    </div>
+  {% include navigation.html %}
 
-    {% include footer.html %}
+  <div class="page-content" id="main-content">
+    {{ content }}
+  </div>
+
+  {% include footer.html %}
 
 </body>
 

--- a/_sass/_pattern_card.scss
+++ b/_sass/_pattern_card.scss
@@ -1,0 +1,17 @@
+@mixin multipass-p-card {
+  .p-card--selection {
+    @extend %vf-card;
+    @extend %vf-is-bordered;
+    background-color: transparent;
+    border-color: transparent;
+
+    &:hover {
+      border-color: $color-mid-light;
+    }
+
+    &[aria-selected='true'] {
+      background-color: $color-x-light;
+      border-color: $color-mid-light;
+    }
+  }
+}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -2,12 +2,30 @@
 
 @import "vanilla-framework/scss/build";
 @import "pattern_separator";
+@import "pattern_card";
 @import "utilities_grid";
 
 @include multipass-u-grid-hacks;
 @include multipass-p-separator;
+@include multipass-p-card;
 
 // XXX Fix for inline image SVGs that do not have dimensions set
 .p-inline-images__item > img {
   width: 100%;
+}
+
+[role='tabpanel'] {
+  &[aria-hidden='true'] {
+    @media (min-width: $breakpoint-medium) {
+      display: none;
+    }
+  }
+
+  @media (max-width: $breakpoint-medium) {
+    border-bottom: 1px solid $color-mid-light;
+  }
+
+  &:last-of-type {
+    border-bottom: 0;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -1,142 +1,125 @@
 ---
 layout: default
+page: home
 ---
-<header id="navigation" class="p-navigation">
+
+<section class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/b2c40eef-multipass-hdr.jpg'); background-position: 75% 50%;">
   <div class="row">
-    <div class="p-navigation__banner">
-      <div class="p-navigation__logo">
-        <a class="p-navigation__link" href="/">
-          <h3 class="p-navigation__image">Multipass</h3>
-        </a>
-      </div>
+    <div class="col-8">
+      <h1>Instant Ubuntu VMs</h1>
+      <p class="p-heading--four">For cloud and Kubernetes developers, turn your workstation into a free mini-cloud with a CLI to launch instances and drive cloud-init.</p>
     </div>
-    <nav class="p-navigation__nav">
-      <span class="u-off-screen">
-        <a href="#main-content">Jump to main content</a>
-      </span>
-    </nav>
   </div>
-</header>
+</section>
 
-<div id="main-content">
-  <section class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/b2c40eef-multipass-hdr.jpg'); background-position: 75% 50%;">
-    <div class="row">
-      <div class="col-8">
-        <h1>Instant Ubuntu VMs</h1>
-        <p class="p-heading--four">For cloud and Kubernetes developers, turn your workstation into a free mini-cloud with a CLI to launch instances and drive cloud-init.</p>
-      </div>
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-12 u-sv3">
+      <h2 class="p-muted-heading">Features</h2>
     </div>
-  </section>
+  </div>
+  <div class="row">
+    <div class="col-4">
+      <div class="u-sv1">
+        <img src="https://assets.ubuntu.com/v1/aeec264b-green-tick.svg" alt="" />
+      </div>
+      <h3 class="p-heading--four">Develop for Ubuntu</h3>
+      <p>Ubuntu is the leading operating system in the cloud and IoT. With Multipass you can target it directly from your developer OS of choice.</p>
+    </div>
+    <div class="col-4">
+      <div class="u-sv1">
+        <img src="https://assets.ubuntu.com/v1/aeec264b-green-tick.svg" alt="" />
+      </div>
+      <h3 class="p-heading--four">Always up to date</h3>
+      <p>Multipass always uses the newest and most up-to-date image available, and will maintain those you use often.</p>
+    </div>
+    <div class="col-4">
+      <div class="u-sv1">
+        <img src="https://assets.ubuntu.com/v1/aeec264b-green-tick.svg" alt="" />
+      </div>
+      <h3 class="p-heading--four">Easy to use</h3>
+      <p>Getting a new instance is as easy as <code>multipass launch</code>.</p>
+    </div>
+  </div>
+</section>
 
-  <section class="p-strip--light">
-    <div class="row">
-      <div class="col-12 u-sv3">
-        <h2 class="p-muted-heading">Features</h2>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-12">
+      <h2 style="font-weight: 100;">Get started</h2>
+      <p>Multipass is available for <a href="/install#macOS">macOS</a> and <a href="/install#windows">Windows</a>, and the many <a href="/install#snap">Linux distributions</a> that support <a href="https://snapcraft.io/" class="p-link--external">snaps</a>.</p>
+    </div>
+  </div>
+  <div class="row p-divider u-equal-height">
+    <div class="col-10 u-clearfix--medium">
+      <div class="mobile-col-2 tablet-col-2 col-2">
+        <img src="https://assets.ubuntu.com/v1/95b929d4-logo-ubuntu.png" alt="Ubuntu">
+      </div>
+      <div class="mobile-col-2 tablet-col-2 col-2">
+        <img src="https://assets.ubuntu.com/v1/afee3c85-logo-MacOS.png" alt="MacOS">
+      </div>
+      <div class="mobile-col-2 tablet-col-2 col-2 u-first-col--small">
+        <img src="https://assets.ubuntu.com/v1/9522d08d-logo-windows.png" alt="Windows">
+      </div>
+      <div class="mobile-col-2 tablet-col-2 col-2 u-first-col--medium">
+        <img src="https://assets.ubuntu.com/v1/f7f680fb-debian.png" alt="Debian">
+      </div>
+      <div class="mobile-col-2 tablet-col-2 col-2 u-first-col--small">
+        <img src="https://assets.ubuntu.com/v1/f24733d2-fedora.png" alt="Fedora">
       </div>
     </div>
-    <div class="row">
-      <div class="col-4">
-        <div class="u-sv1">
-          <img src="https://assets.ubuntu.com/v1/aeec264b-green-tick.svg" alt="" />
-        </div>
-        <h3 class="p-heading--four">Develop for Ubuntu</h3>
-        <p>Ubuntu is the leading operating system in the cloud and IoT. With Multipass you can target it directly from your developer OS of choice.</p>
-      </div>
-      <div class="col-4">
-        <div class="u-sv1">
-          <img src="https://assets.ubuntu.com/v1/aeec264b-green-tick.svg" alt="" />
-        </div>
-        <h3 class="p-heading--four">Always up to date</h3>
-        <p>Multipass always uses the newest and most up-to-date image available, and will maintain those you use often.</p>
-      </div>
-      <div class="col-4">
-        <div class="u-sv1">
-          <img src="https://assets.ubuntu.com/v1/aeec264b-green-tick.svg" alt="" />
-        </div>
-        <h3 class="p-heading--four">Easy to use</h3>
-        <p>Getting a new instance is as easy as <code>multipass launch</code>.</p>
-      </div>
+    <div class="col-2 p-divider__block u-vertically-center">
+      <a class="p-link--external" href="https://docs.snapcraft.io/installing-snapd/6735">See all the distributions that run snapd</a>
     </div>
-  </section>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <p>Once you've installed Multipass, check out <code>multipass find</code> to see what images are available for you and start one via <code>multipass launch</code>. See <code>multipass help</code> for information on all the commands.</p>
+      <p class="u-no-margin--bottom"><a href="/install" class="p-button--positive">Install Multipass now</a></p>
+    </div>
+  </div>
+  <div class="row">
+    <hr class="p-separator">
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <h3 class="p-heading--two" style="font-weight: 100;">Learn more</h3>
+    </div>
+  </div>
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block">
+      <h4>Documentation</h4>
+      <p><a href="https://discourse.ubuntu.com/c/multipass/doc" class="p-link--external">Documentation and guidance on using Multipass</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h4>Using cloud-init</h4>
+      <p><a href="https://blog.ubuntu.com/2018/04/02/using-cloud-init-with-multipass" class="p-link--external">Learn how to use cloud-init with Multipass to customize your instances</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      <h4>Participate</h4>
+      <ul class="p-list">
+        <li class="p-list__item">
+          <a href="https://webchat.freenode.net/?channels=#multipass" class="p-link--external">Multipass on Freenode</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://github.com/CanonicalLtd/multipass" class="p-link--external">Multipass on GitHub</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://discourse.ubuntu.com/c/multipass" class="p-link--external">Multipass on Ubuntu discourse</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
 
-  <section class="p-strip">
-    <div class="row">
-      <div class="col-12">
-        <h2 style="font-weight: 100;">Get started</h2>
-        <p>Multipass is available for <a href="/install#macOS">macOS</a> and <a href="/install#windows">Windows</a>, and the many <a href="/install#snap">Linux distributions</a> that support <a href="https://snapcraft.io/" class="p-link--external">snaps</a>.</p>
-      </div>
+<section class="p-strip--image is-shallow is-dark" style="background-image: url('https://assets.ubuntu.com/v1/b2c40eef-multipass-hdr.jpg'); background-position: 75% 50%;">
+  <div class="row u-equal-height">
+    <div class="col-8">
+      <h4 class="p-heading--two u-no-margin--bottom" style="font-weight: 100;">Multipass speeds up your development process</h4>
     </div>
-    <div class="row p-divider u-equal-height">
-      <div class="col-10 u-clearfix--medium">
-        <div class="mobile-col-2 tablet-col-2 col-2">
-          <img src="https://assets.ubuntu.com/v1/95b929d4-logo-ubuntu.png" alt="Ubuntu">
-        </div>
-        <div class="mobile-col-2 tablet-col-2 col-2">
-          <img src="https://assets.ubuntu.com/v1/afee3c85-logo-MacOS.png" alt="MacOS">
-        </div>
-        <div class="mobile-col-2 tablet-col-2 col-2 u-first-col--small">
-          <img src="https://assets.ubuntu.com/v1/9522d08d-logo-windows.png" alt="Windows">
-        </div>
-        <div class="mobile-col-2 tablet-col-2 col-2 u-first-col--medium">
-          <img src="https://assets.ubuntu.com/v1/f7f680fb-debian.png" alt="Debian">
-        </div>
-        <div class="mobile-col-2 tablet-col-2 col-2 u-first-col--small">
-          <img src="https://assets.ubuntu.com/v1/f24733d2-fedora.png" alt="Fedora">
-        </div>
-      </div>
-      <div class="col-2 p-divider__block u-vertically-center">
-        <a class="p-link--external" href="https://docs.snapcraft.io/installing-snapd/6735">See all the distributions that run snapd</a>
-      </div>
+    <div class="col-4 u-vertically-center u-text-align--right">
+      <br class="u-hide--large u-hide--medium" />
+      <a href="/install" class="p-button--positive u-no-margin--bottom">Launch your first instance now</a>
     </div>
-    <div class="row">
-      <div class="col-8">
-        <p>Once you've installed Multipass, check out <code>multipass find</code> to see what images are available for you and start one via <code>multipass launch</code>. See <code>multipass help</code> for information on all the commands.</p>
-        <p class="u-no-margin--bottom"><a href="/install" class="p-button--positive">Install Multipass now</a></p>
-      </div>
-    </div>
-    <div class="row">
-      <hr class="p-separator">
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <h3 class="p-heading--two" style="font-weight: 100;">Learn more</h3>
-      </div>
-    </div>
-    <div class="row p-divider">
-      <div class="col-4 p-divider__block">
-        <h4>Documentation</h4>
-        <p><a href="https://discourse.ubuntu.com/c/multipass/doc" class="p-link--external">Documentation and guidance on using Multipass</a></p>
-      </div>
-      <div class="col-4 p-divider__block">
-        <h4>Using cloud-init</h4>
-        <p><a href="https://blog.ubuntu.com/2018/04/02/using-cloud-init-with-multipass" class="p-link--external">Learn how to use cloud-init with Multipass to customize your instances</a></p>
-      </div>
-      <div class="col-4 p-divider__block">
-        <h4>Participate</h4>
-        <ul class="p-list">
-          <li class="p-list__item">
-            <a href="https://webchat.freenode.net/?channels=#multipass" class="p-link--external">Multipass on Freenode</a>
-          </li>
-          <li class="p-list__item">
-            <a href="https://github.com/CanonicalLtd/multipass" class="p-link--external">Multipass on GitHub</a>
-          </li>
-          <li class="p-list__item">
-            <a href="https://discourse.ubuntu.com/c/multipass" class="p-link--external">Multipass on Ubuntu discourse</a>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </section>
-
-  <section class="p-strip--image is-shallow is-dark" style="background-image: url('https://assets.ubuntu.com/v1/b2c40eef-multipass-hdr.jpg'); background-position: 75% 50%;">
-    <div class="row u-equal-height">
-      <div class="col-8">
-        <h4 class="p-heading--two u-no-margin--bottom" style="font-weight: 100;">Multipass speeds up your development process</h4>
-      </div>
-      <div class="col-4 u-vertically-center u-text-align--right">
-        <br class="u-hide--large u-hide--medium" />
-        <a href="/install" class="p-button--positive u-no-margin--bottom">Launch your first instance now</a>
-      </div>
-    </div>
-  </section>
-</div>
+  </div>
+</section>

--- a/install.html
+++ b/install.html
@@ -50,8 +50,8 @@ page: install
       aria-controls="linux-install"
       id="macos-tab"
       tabindex="0">
-      <div class="u-sv3">
-        <img src="https://assets.ubuntu.com/v1/53c3be42-linuc-logo.svg?w=123" width="123" alt="Linux" />
+      <div style="padding: 30px 0 50px;">
+        <img src="https://assets.ubuntu.com/v1/a5a05bab-logo-linux.png" alt="Linux" />
       </div>
       <p>Linux</p>
     </a>
@@ -141,6 +141,7 @@ page: install
   let os = 'linux';
   if (navigator.appVersion.indexOf('Win') != -1) { os = 'windows' };
   if (navigator.appVersion.indexOf('MacOS') != -1) { os = 'macos' };
+  if (navigator.appVersion.indexOf('Mac OS') != -1) { os = 'macos' };
 
   // Add a click listener to all tabs
   for (var i = 0; i < tabs.length; i++) {

--- a/install.html
+++ b/install.html
@@ -1,0 +1,208 @@
+---
+layout: default
+page: install
+---
+
+<section class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/b2c40eef-multipass-hdr.jpg'); background-position: 75% 50%;">
+  <div class="row">
+    <div class="col-8">
+      <h1>Get started with Multipass</h1>
+      <p class="p-heading--four">Installing Multipass is quick and easy. Follow the instructions for the Operating System of your choice and multipass will be available on your command line.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light is-bordered">
+  <div class="row">
+    <div class="col-12">
+      <h2>Installing Multipass</h2>
+    </div>
+  </div>
+  <div class="row u-equal-height u-hide--small" role="tablist">
+    <a class="col-4 p-card--selection u-align--center"
+      href="#macos-install"
+      role="tab"
+      aria-selected="false"
+      aria-controls="macos-install"
+      id="macos-tab"
+      tabindex="0">
+      <div class="u-sv3">
+        <img src="https://assets.ubuntu.com/v1/236f314d-macos.svg" alt="macOS" />
+      </div>
+      <p>macOS</p>
+    </a>
+    <a class="col-4 p-card--selection u-align--center"
+      href="#windows-install"
+      role="tab"
+      aria-selected="false"
+      aria-controls="windows-install"
+      id="windows-tab"
+      tabindex="0">
+      <div class="u-sv3">
+        <img src="https://assets.ubuntu.com/v1/11ecbd2d-2018-logo-windows.svg" alt="Windows" />
+      </div>
+      <p>Windows</p>
+    </a>
+    <a class="col-4 p-card--selection u-align--center"
+      href="#linux-install"
+      role="tab"
+      aria-selected="true"
+      aria-controls="linux-install"
+      id="macos-tab"
+      tabindex="0">
+      <div class="u-sv3">
+        <img src="https://assets.ubuntu.com/v1/53c3be42-linuc-logo.svg?w=123" width="123" alt="Linux" />
+      </div>
+      <p>Linux</p>
+    </a>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <div role="tabpanel"
+        aria-hidden="true"
+        id="macos-install"
+        aria-labelledby="macos-tab">
+        <div class="u-hide--large u-hide--medium">
+          <img src="https://assets.ubuntu.com/v1/236f314d-macos.svg" alt="macOS" />
+        </div>
+        <p>Requirements:</p>
+        <ul>
+          <li>OS X 10.10.3 Yosemite or later</li>
+          <li>a 2010 or later Mac (i.e. a CPU that supports EPT)</li>
+        </ul>
+        <p>Download the installer, run it and follow the on-screen instructions.</p>
+        <p>Then, start the Terminal app and run <code>multipass help</code> to see the available commands.</p>
+        <p><a href="#" class="p-button--positive">
+          <span class="p-link--external">Download</span>
+        </a></p>
+      </div>
+      <div role="tabpanel"
+        aria-hidden="true"
+        id="windows-install"
+        aria-labelledby="windows-tab">
+        <div class="u-hide--large u-hide--medium">
+          <img src="https://assets.ubuntu.com/v1/11ecbd2d-2018-logo-windows.svg" alt="Windows" />
+        </div>
+        <p>Requirements:</p>
+        <ul>
+          <li>Windows 10 Enterprise, Professional or Education</li>
+          <li>A 64-bit CPU that supports virtualization</li>
+          <li>Support for virtualization enabled in your BIOS</li>
+        </ul>
+        <p>Download the installer, run it and follow the on-screen instructions.</p>
+        <p>Then, start the Terminal app or PowerShell and run <code>multipass help</code> to see the available commands.</p>
+        <p><a href="#" class="p-button--positive">
+          <span class="p-link--external">Download</span>
+        </a></p>
+      </div>
+      <div role="tabpanel"
+        aria-hidden="false"
+        id="linux-install"
+        aria-labelledby="linux-tab">
+        <div class="u-hide--large u-hide--medium">
+          <img src="https://assets.ubuntu.com/v1/53c3be42-linuc-logo.svg?w=123" width="123" alt="Linux" />
+        </div>
+        <p>Requirements:</p>
+        <ul>
+          <li>A Linux distribution with supports for snaps</li>
+          <li>A 64-bit CPU that supports virtualization</li>
+          <li>Support for virtualization enabled in your BIOS</li>
+        </ul>
+        <p>To install, find Multipass in your Software Center or run:</p>
+        <div class="p-code-snippet">
+          <input class="p-code-snippet__input" value="snap install multipass" readonly="readonly">
+          <button class="p-code-snippet__action">Copy to clipboard</button>
+        </div>
+        <p>Then, start a terminal of your choice and run <code>multipass help</code> to see the available commands.</p>
+        <p><a href="https://snapcraft.io/multipass" class="p-link--external">Find Multipass on the Snap Store</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8 suffix-1">
+      <h2 style="font-weight: 100;">Next steps</h2>
+      <p>Once you have installed Multipass, run <code>multipass find</code> to list the images available, <code>multipass launch</code> to just launch the default one or <code>multipass help</code> to see all the available commands.</p>
+      <p>Multipass is integrated into many workflows and tools that were normally limited only to Linux. Now you can work with Ubuntu without having to adapt your work environment.</p>
+    </div>
+    <div class="col-4">
+      <div class="p-card">
+        <h3>Work with us</h3>
+        <p>We greatly value your feedback. Please <a href="https://github.com/CanonicalLtd/multipass/issues/new" class="p-link--external">file a report on GitHub</a> if you feel something isn't working right or to suggest a workflow we don't support yet. You can also come to <a href="https://webchat.freenode.net/?channels=#multipass" class="p-link--external">#multipass on Freenode</a> or post messages on <a href="https://discourse.ubuntu.com/c/multipass" class="p-link--external">the Ubuntu Discourse</a>.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  const tabs = document.querySelectorAll('[role="tab"]');
+
+  // Add a click listener to all tabs
+  for (var i = 0; i < tabs.length; i++) {
+    tabs[i].addEventListener('click', function(e) {
+      let control = this.getAttribute("aria-controls");
+      toogleHandler(control);
+    });
+  };
+
+  function toogleHandler(control) {
+    let tabpanels = document.querySelectorAll('[role="tabpanel"]');
+    let selectedTab = document.querySelector(`[aria-controls="${control}"]`);
+    let selectedPanel = document.getElementById(control);
+
+    // Hide all panels
+    for (var i = 0; i < tabpanels.length; i++) {
+      tabpanels[i].setAttribute('aria-hidden', 'true');
+    }
+
+    // Remove tab highlight
+    for (var i = 0; i < tabs.length; i++) {
+      tabs[i].setAttribute('aria-selected', 'false');
+    }
+
+    // Select the current tab to selected
+    selectedTab.setAttribute('aria-selected', 'true');
+
+    // Reveal the assosiated tabpanel
+    selectedPanel.setAttribute('aria-hidden', 'false');
+  }
+</script>
+
+<script>
+  const copyToClipboard = str => {
+    const el = document.createElement('textarea'); // Create a <textarea> element
+    el.value = str; // Set its value to the string that you want copied
+    el.setAttribute('readonly', ''); // Make it readonly to be tamper-proof
+    el.style.position = 'absolute';
+    el.style.left = '-9999px'; // Move outside the screen to make it invisible
+    document.body.appendChild(el); // Append the <textarea> element to the HTML document
+    const selected =
+      document.getSelection().rangeCount > 0 // Check if there is any content selected previously
+        ? document.getSelection().getRangeAt(0) // Store selection if found
+        : false; // Mark as false to know no selection existed before
+    el.select(); // Select the <textarea> content
+    document.execCommand('copy'); // Copy - only works as a result of a user action (e.g. click events)
+    document.body.removeChild(el); // Remove the <textarea> element
+    if (selected) {
+      // If a selection existed before copying
+      document.getSelection().removeAllRanges(); // Unselect everything on the HTML document
+      document.getSelection().addRange(selected); // Restore the original selection
+    }
+  };
+
+  var codeSnippetActions = document.querySelectorAll(
+    '.p-code-snippet__action'
+  );
+  for (var codeSnippetAction of codeSnippetActions) {
+    codeSnippetAction.addEventListener(
+      'click',
+      function(e) {
+        const clipboardValue = this.previousSibling.previousSibling.value;
+        copyToClipboard(clipboardValue);
+      },
+      false
+    );
+  }
+</script>

--- a/install.html
+++ b/install.html
@@ -137,8 +137,8 @@ page: install
 </section>
 
 <script>
-  const tabs = document.querySelectorAll('[role="tab"]');
-  let os = 'linux';
+  var tabs = document.querySelectorAll('[role="tab"]');
+  var os = 'linux';
   if (navigator.appVersion.indexOf('Win') != -1) { os = 'windows' };
   if (navigator.appVersion.indexOf('MacOS') != -1) { os = 'macos' };
   if (navigator.appVersion.indexOf('Mac OS') != -1) { os = 'macos' };
@@ -146,16 +146,15 @@ page: install
   // Add a click listener to all tabs
   for (var i = 0; i < tabs.length; i++) {
     tabs[i].addEventListener('click', function(e) {
-      let control = this.getAttribute("aria-controls");
+      var control = this.getAttribute("aria-controls");
       toogleHandler(control);
     });
   };
 
   function toogleHandler(control) {
-    console.log(control)
-    let tabpanels = document.querySelectorAll('[role="tabpanel"]');
-    let selectedTab = document.querySelector(`[aria-controls="${control}"]`);
-    let selectedPanel = document.getElementById(control);
+    var tabpanels = document.querySelectorAll('[role="tabpanel"]');
+    var selectedTab = document.querySelector('[aria-controls="' + control + '"]');
+    var selectedPanel = document.getElementById(control);
 
     // Hide all panels
     for (var i = 0; i < tabpanels.length; i++) {
@@ -174,25 +173,25 @@ page: install
     selectedPanel.setAttribute('aria-hidden', 'false');
   }
 
-  const hash = window.location.hash;
+  var hash = window.location.hash;
   if (hash) {
     toogleHandler(hash.replace('#', ''));
   } else {
-    if (os != 'linux') {
+    if (os !== 'linux') {
       toogleHandler(`${os}-install`);
     }
   }
 </script>
 
 <script>
-  const copyToClipboard = str => {
-    const el = document.createElement('textarea'); // Create a <textarea> element
+  var copyToClipboard = function(str) {
+    var el = document.createElement('textarea'); // Create a <textarea> element
     el.value = str; // Set its value to the string that you want copied
     el.setAttribute('readonly', ''); // Make it readonly to be tamper-proof
     el.style.position = 'absolute';
     el.style.left = '-9999px'; // Move outside the screen to make it invisible
     document.body.appendChild(el); // Append the <textarea> element to the HTML document
-    const selected =
+    var selected =
       document.getSelection().rangeCount > 0 // Check if there is any content selected previously
         ? document.getSelection().getRangeAt(0) // Store selection if found
         : false; // Mark as false to know no selection existed before
@@ -213,7 +212,7 @@ page: install
     codeSnippetAction.addEventListener(
       'click',
       function(e) {
-        const clipboardValue = this.previousSibling.previousSibling.value;
+        var clipboardValue = this.previousSibling.previousSibling.value;
         copyToClipboard(clipboardValue);
       },
       false

--- a/install.html
+++ b/install.html
@@ -99,8 +99,8 @@ page: install
         aria-hidden="false"
         id="linux-install"
         aria-labelledby="linux-tab">
-        <div class="u-hide--large u-hide--medium">
-          <img src="https://assets.ubuntu.com/v1/53c3be42-linuc-logo.svg?w=123" width="123" alt="Linux" />
+        <div class="u-hide--large u-hide--medium" style="padding: 30px 0;">
+          <img src="https://assets.ubuntu.com/v1/a5a05bab-logo-linux.png" alt="Linux" />
         </div>
         <p>Requirements:</p>
         <ul>

--- a/install.html
+++ b/install.html
@@ -12,10 +12,10 @@ page: install
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip--light">
   <div class="row">
     <div class="col-12">
-      <h2>Installing Multipass</h2>
+      <h2 style="font-weight: 100;">Installing Multipass</h2>
     </div>
   </div>
   <div class="row u-equal-height u-hide--small" role="tablist">
@@ -128,8 +128,8 @@ page: install
       <p>Multipass is integrated into many workflows and tools that were normally limited only to Linux. Now you can work with Ubuntu without having to adapt your work environment.</p>
     </div>
     <div class="col-4">
-      <div class="p-card">
-        <h3>Work with us</h3>
+      <div class="p-card u-no-margin--bottom">
+        <h3 class="p-heading--four">Work with us</h3>
         <p>We greatly value your feedback. Please <a href="https://github.com/CanonicalLtd/multipass/issues/new" class="p-link--external">file a report on GitHub</a> if you feel something isn't working right or to suggest a workflow we don't support yet. You can also come to <a href="https://webchat.freenode.net/?channels=#multipass" class="p-link--external">#multipass on Freenode</a> or post messages on <a href="https://discourse.ubuntu.com/c/multipass" class="p-link--external">the Ubuntu Discourse</a>.</p>
       </div>
     </div>
@@ -138,6 +138,9 @@ page: install
 
 <script>
   const tabs = document.querySelectorAll('[role="tab"]');
+  let os = 'linux';
+  if (navigator.appVersion.indexOf('Win') != -1) { os = 'windows' };
+  if (navigator.appVersion.indexOf('MacOS') != -1) { os = 'macos' };
 
   // Add a click listener to all tabs
   for (var i = 0; i < tabs.length; i++) {
@@ -148,6 +151,7 @@ page: install
   };
 
   function toogleHandler(control) {
+    console.log(control)
     let tabpanels = document.querySelectorAll('[role="tabpanel"]');
     let selectedTab = document.querySelector(`[aria-controls="${control}"]`);
     let selectedPanel = document.getElementById(control);
@@ -167,6 +171,15 @@ page: install
 
     // Reveal the assosiated tabpanel
     selectedPanel.setAttribute('aria-hidden', 'false');
+  }
+
+  const hash = window.location.hash;
+  if (hash) {
+    toogleHandler(hash.replace('#', ''));
+  } else {
+    if (os != 'linux') {
+      toogleHandler(`${os}-install`);
+    }
   }
 </script>
 


### PR DESCRIPTION
## Done
- Created the /install page
- Structured the site to have a common navigation
- Added the OS detection to the tabed install instructions

## QA
- Go to /install
- Check it matches [the copydoc](https://docs.google.com/document/d/1u8j5uN5d8qSEPDAjA03CGLeTJGf2p2MnHaKARkVmy7w/edit#heading=h.nel9e5tlwcfr)
- Check it [matches the design](https://camo.zenhubusercontent.com/79d4720049bfd269fc3b0beaa346535489f8f839/68747470733a2f2f757365722d696d616765732e67697468756275736572636f6e74656e742e636f6d2f393130353939392f35363336343733302d33343062333438302d363165372d313165392d393663372d6232363337653165643235392e706e67) _Agreed to change the instructions section to grey with hover and active state cards_
- Click on the different OS installs and check it jumps to the instructions about them
- Check loading the page with a hash auto selects the OS
- If you can check on a different OS for the auto detection (or just check the `os` variable in the page scripts)
- Check small screens work

Fixes https://github.com/canonical-web-and-design/multipass.run/issues/14