### PR TITLE
Add snapcraft badge on install page

### DIFF
--- a/install.html
+++ b/install.html
@@ -116,6 +116,7 @@ page: install
           <input class="p-code-snippet__input" value="snap install multipass" readonly="readonly">
           <button class="p-code-snippet__action">Copy to clipboard</button>
         </div>
+        <p><a href="https://snapcraft.io/multipass"><img src="https://snapcraft.io/static/images/badges/en/snap-store-black.svg" alt="Multipass snap details page"></a></p>
         <p>Then, start a terminal of your choice and run <code>multipass help</code> to see the available commands.</p>
         <p><a href="https://snapcraft.io/multipass" class="p-link--external">Find Multipass on the Snap Store</a></p>
       </div>


### PR DESCRIPTION
## Done
Added a snapcraft badge on install page for linux

## QA
- Go to /install
- Select linux (for not already selected)
- See the snapcraft badge looks good and links to the correct snap

Fixes https://github.com/canonical-web-and-design/multipass.run/issues/26