### PR TITLE
Skip the prerelease releases when generating the download link

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@ page: home
       <div class="u-sv3">
         <p>Run commands in that instance, try running bash (logout or ctrl-d to quit)</p>
         <div class="p-code-snippet">
-          <input class="p-code-snippet__input" value="multipass exec foo lsb_release -a" readonly="readonly">
+          <input class="p-code-snippet__input" value="multipass exec foo -- lsb_release -a" readonly="readonly">
           <button class="p-code-snippet__action">Copy to clipboard</button>
         </div>
       </div>

--- a/js/installversion.js
+++ b/js/installversion.js
@@ -36,7 +36,7 @@ function getAssetInfo(os) {
     var assets = release.assets;
     for (var q = 0; q < assets.length; q++) {
       var asset = assets[q];
-      if (asset.name.includes(os)) {
+      if (asset.name.includes(os) && release.target_commitish == 'master') {
         if (asset.browser_download_url && release.tag_name) {
           return {
             url: asset.browser_download_url,


### PR DESCRIPTION
## Done
Skip the prerelease releases when generating the download link 
_Drive by_: Small copy update from the [copy doc](https://docs.google.com/document/d/1uI5hsuhe5VUpFSSiQas6FVB2F7RhlbNXcr5Pvr_Lm2c/edit?ts=5cdd0e58#)

## QA
- Check the homepage
- See that the download buttons link to v1.6.0 instead of v1.7.0

Fixes https://github.com/canonical-web-and-design/multipass.run/issues/35