### PR TITLE
Add system requirements to download area

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,18 +87,22 @@ page: home
       <p><a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--neutral js-download" data-os="win-win">
         <span class="p-link--external">Download Multipass for Windows</span>
       </a></p>
+      <p>Windows 10 Pro/Enterprise v 1803 or later</p>
+      <p><i>or</i> Windows 10 Home/Pro/Enterprise with Virtualbox</p>
     </div>
     <div class="col-4">
       <img src="https://assets.ubuntu.com/v1/236f314d-macos.svg" alt="macOS logo" />
       <p><a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--neutral js-download" data-os="mac">
         <span class="p-link--external">Download Multipass for MacOS</span>
       </a></p>
+      <p>Yosemite 10.10.3 or later, 2010 or newer Mac</p>
     </div>
     <div class="col-4">
       <img src="https://assets.ubuntu.com/v1/53c3be42-linuc-logo.svg" alt="Linux logo" style="margin: 27px 0;height: 90px;" />
       <p><a href="https://snapcraft.io/multipass" class="p-button--neutral js-download" data-os="linux">
         <span class="p-link--external">Install the Multipass snap</span>
       </a></p>
+      <p>Linux distributions with snap packages support enabled. <a href="https://docs.snapcraft.io/installing-snapd" class="p-link--external">Get your Linux set up for snaps</a></p>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done

Added system requirements to the "Install Multipass" section

## QA
- Check out this feature branch
- Run the site using the command ./run serve
- View the site locally in your web browser at: http://127.0.0.1:8026
- Run through the following QA steps
- Please ensure the changes are reflected on the takeover:
  - The system requirements are included as specified in the [issue](https://github.com/canonical-web-and-design/multipass.run/issues/42)

## Fixes
Fixes #42