### PR TITLE
Update to new vanilla spacing variables

### DIFF
--- a/_sass/_pattern_separator.scss
+++ b/_sass/_pattern_separator.scss
@@ -1,9 +1,9 @@
 @mixin multipass-p-separator {
   .p-separator {
-    margin: $spv-inter--regular-scaleable 0;
+    margin: $spv-outer--regular-scaleable 0;
 
     @media (max-width: $breakpoint-medium) {
-      margin: $spv-inter--shallow-scaleable 0;
+      margin: $spv-outer--shallow-scaleable  0;
     }
   }
 }


### PR DESCRIPTION
1. Download this branch
2. Run the site and see that it looks ok
3. See that the css updates use the new spacing variables as suggested in [this doc](https://assets.ubuntu.com/v1/d4964abe-Vanilla+2+spacing+variables.pdf)