### PR TITLE
Defer scripts and move them to head

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,4 +11,7 @@
     <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/b9411b66-Multipass-favicon_128px.png" sizes="128x128" />
     <link rel="stylesheet" href="{{ "css/main.css" | prepend: site.baseurl }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+    <script src="/js/installversion.js" defer></script>
+    <script src="/js/osselector.js" defer></script>
+    <script src="/js/copytoclipboard.js" defer></script>
 </head>

--- a/index.html
+++ b/index.html
@@ -215,7 +215,3 @@ page: home
     </div>
   </div>
 </section>
-
-<script src="/js/installversion.js" async></script>
-<script src="/js/osselector.js" async></script>
-<script src="/js/copytoclipboard.js" async></script>


### PR DESCRIPTION
## Done

- Defer `installversion`, `osselector` & `copytoclipboard` scripts and move them to `head`

##QA

- Go to http://0.0.0.0:8026/ and check if it works as expected

## Issue

Fixes #53 