### PR TITLE
Remove useless redirect

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -19,10 +19,6 @@ server {
 
     server_name _;
 
-    # Redirects
-    rewrite ^/apps(.*) https://docs.ubuntu.com/phone/en/apps/index permanent;
-    rewrite ^/scopes(.*) https://docs.ubuntu.com/phone/en/scopes/index permanent;
-
     # Remove index or index.html from URIs
     if ($request_uri ~ ^.*/index(.html)?$) {
         rewrite ^(.*/)index(.html)? $1 permanent;
@@ -43,5 +39,9 @@ server {
     # Finally fall back to 404
     location ~ ^/.+$ {
         try_files $uri $uri.html $uri/ =404;
+    }
+
+    location /_status/check {
+        return "OK"
     }
 }


### PR DESCRIPTION
# Summary 

Remove useless redirect due to a copy paste.
Add `/_status/check`  endpoint

# QA

- `./run`
- http://0.0.0.0:8026/apps should return 404
- http://0.0.0.0:8026/scopes should return 404
- http://0.0.0.0:8026/_status/check should return `OK`