### PR TITLE
Set up /static/latest-release.json

### DIFF
--- a/static/latest-release.json
+++ b/static/latest-release.json
@@ -1,0 +1,11 @@
+{
+    "version": "0.9.0",
+    "title": "Multipass 0.9.0 release",
+    "description": "Better desktop integration of the system menu",
+    "download_url": "https://multipass.run/#install",
+    "release_url": "https://github.com/CanonicalLtd/multipass/releases/tag/v0.9.0",
+    "installer_urls": {
+        "windows": "https://github.com/CanonicalLtd/multipass/releases/download/v0.9.0/multipass-0.9.0%2Bwin-win64.exe",
+        "macos": "https://github.com/CanonicalLtd/multipass/releases/download/v0.9.0/multipass-0.9.0%2Bmac-Darwin.pkg"
+    }
+}

--- a/update.json
+++ b/update.json
@@ -1,4 +1,0 @@
-{
-  "html_url": "https://github.com/CanonicalLtd/multipass/releases/tag/v0.9.0",
-  "tag_name": "v0.9.0"
-}

--- a/update.yaml
+++ b/update.yaml
@@ -1,8 +1,0 @@
-version: 0.9.0
-title: Multipass 0.9.0 release
-description: Better desktop integration of the system menu
-download_url: https://multipass.run/#install
-release_url: https://github.com/CanonicalLtd/multipass/releases/tag/v0.9.0
-installer_urls:
-  windows: https://github.com/CanonicalLtd/multipass/releases/download/v0.9.0/multipass-0.9.0%2Bwin-win64.exe
-  macos: https://github.com/CanonicalLtd/multipass/releases/download/v0.9.0/multipass-0.9.0%2Bmac-Darwin.pkg

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,5 +1,8 @@
-from canonicalwebteam.flask_base.app import FlaskBase
+# Packages
 from flask import render_template
+
+# Local
+from canonicalwebteam.flask_base.app import FlaskBase
 
 
 app = FlaskBase(


### PR DESCRIPTION
This builds on https://github.com/canonical-web-and-design/multipass.run/pull/62, which introduced this format but doesn't actually work.

I'm only including a JSON endpoint because:

> @Saviq, @ricab: actually, could I suggest that json is a better format for this?
> 
> Firstly, because it's intended to be consumed by code, not by humans, so it's really more of an API. JSON is the common interchange format for APIs.
> 
> But also, it's actually kinda more user friendly, in that if we serve /update.json with a application/json content-type (as we should), most browser will at least display that as text, and some (Firefox) will present it quite nicely.
> 
> ![image](https://user-images.githubusercontent.com/519935/70530052-eebabf00-1b49-11ea-8bf4-bedeacbabda4.png)
> 
> Whereas all of the content-types we could use for /update.yaml (application/x-yaml, text/yaml, text/x-yaml) result in the browser prompting the user to download the file, which is much less user friendly.

https://github.com/canonical-web-and-design/multipass.run/pull/62#issuecomment-564011256

QA
--

Either go to https://multipass-run-canonical-web-and-design-pr-64.run.demo.haus/ and https://multipass-run-canonical-web-and-design-pr-64.run.demo.haus/update.json to check.

Or pull down the code locally, run `./run`, go to http://0.0.0.0:8026/, see the site works. Then go to http://0.0.0.0:8026/update.json and check you see the version info.