### PR TITLE
Add report a bug on product link to footer

### DIFF
--- a/templates/_layouts/default.html
+++ b/templates/_layouts/default.html
@@ -91,6 +91,12 @@
             </li>
             <li class="p-inline-list__item">
               <a
+                href="https://github.com/canonical/multipass/issues/new">
+                Report a bug on Multipass itself
+              </a>
+            </li>
+            <li class="p-inline-list__item">
+              <a
                 aria-label="External link to report a bug on this site"
                 href="https://github.com/canonical-web-and-design/multipass.run/issues/new">
                 Report a bug on this site
@@ -104,7 +110,7 @@
       </div>
     </div>
   </footer>
-  
+
   <script src="/static/js/modules/global-nav.js"></script>
   <script>canonicalGlobalNav.createNav({maxWidth: '72rem'});</script>
 </body>


### PR DESCRIPTION
##Done
Add report a bug on product link to footer

## QA
- Check out the demo
- Scroll to the footer and check the report a link on Multipass itself is there

Fixes https://github.com/canonical-web-and-design/multipass.run/issues/78