### PR TITLE
Minimum macOS version 10.10.3 > 10.12.0

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -93,7 +93,7 @@
       <p><a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--neutral js-download" data-os="mac">
         <span class="p-link--external">Download Multipass for MacOS</span>
       </a></p>
-      <p>Yosemite 10.10.3 or later, 2010 or newer Mac</p>
+      <p>Sierra 10.12.0 or later, 2010 or newer Mac</p>
     </div>
     <div class="col-4">
       <img src="https://assets.ubuntu.com/v1/53c3be42-linuc-logo.svg" alt="Linux logo" style="margin: 27px 0;height: 90px;" />


### PR DESCRIPTION
Resolves #75, the Web site description of the minimum macOS version.