### PR TITLE
Corrects alt= text for OS logos

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -81,7 +81,7 @@
   </div>
   <div class="row">
     <div class="col-4">
-      <img src="https://assets.ubuntu.com/v1/11ecbd2d-2018-logo-windows.svg" alt="Windows logo" />
+      <img src="https://assets.ubuntu.com/v1/11ecbd2d-2018-logo-windows.svg" alt="Windows" />
       <p><a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--neutral js-download" data-os="win-win">
         <span class="p-link--external">Download Multipass for Windows</span>
       </a></p>
@@ -89,14 +89,14 @@
       <p><i>or</i> Windows 10 Home/Pro/Enterprise with Virtualbox</p>
     </div>
     <div class="col-4">
-      <img src="https://assets.ubuntu.com/v1/236f314d-macos.svg" alt="macOS logo" />
+      <img src="https://assets.ubuntu.com/v1/236f314d-macos.svg" alt="macOS" />
       <p><a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--neutral js-download" data-os="mac">
-        <span class="p-link--external">Download Multipass for MacOS</span>
+        <span class="p-link--external">Download Multipass for macOS</span>
       </a></p>
       <p>Sierra 10.12.0 or later, 2010 or newer Mac</p>
     </div>
     <div class="col-4">
-      <img src="https://assets.ubuntu.com/v1/53c3be42-linuc-logo.svg" alt="Linux logo" style="margin: 27px 0;height: 90px;" />
+      <img src="https://assets.ubuntu.com/v1/53c3be42-linuc-logo.svg" alt="Linux" style="margin: 27px 0;height: 90px;" />
       <p><a href="https://snapcraft.io/multipass" class="p-button--neutral js-download" data-os="linux">
         <span class="p-link--external">Install the Multipass snap</span>
       </a></p>


### PR DESCRIPTION
Reverts the part of #33 that changed `alt="Windows"` to `alt="Windows logo"`, `alt="macOS"` to `alt="macOS logo"`, and `alt="Linux"` to `alt="Linux logo"`.

[As explained in the HTML spec](https://html.spec.whatwg.org/multipage/images.html#a-short-phrase-or-label-with-an-alternative-graphical-representation:-icons,-logos): “If the logo is being used to represent the entity, e.g. as a page heading, the `alt` attribute must contain the name of the entity being represented by the logo. The `alt` attribute must _not_ contain text like the word "logo", as it is not the fact that it is a logo that is being conveyed, it's the entity itself.”

[Discovered while designing #55.]