### PR TITLE
Update site to new GTM container

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 PORT=8026
 FLASK_DEBUG=true
 DEVEL=true
+SECRET_KEY=no_key_on_dev

--- a/templates/_layouts/default.html
+++ b/templates/_layouts/default.html
@@ -12,36 +12,25 @@
   <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/a12a3159-Multipass-favicon_32px.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/f1262535-Multipass-favicon_64px.png" sizes="64x64" />
   <link rel="icon" type="image/png" href="https://assets.ubuntu.com/v1/b9411b66-Multipass-favicon_128px.png" sizes="128x128" />
-  <link rel="stylesheet" href="/static/css/main.css">
-  <script src="/static/js/installversion.js" defer></script>
-  <script src="/static/js/osselector.js" defer></script>
-  <script src="/static/js/copytoclipboard.js" defer></script>
-</head>
-
-<body>
-  <script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-  ga('create', 'UA-1018242-59', 'auto', {'allowLinker': true});
-  ga('require', 'GTM-N2MDH37');
-  ga('require', 'linker');
-  ga('linker:autoLink', ['conjure-up.io', 'login.ubuntu.com', 'www.ubuntu.com',
-  'ubuntu.com', 'insights.ubuntu.com', 'developer.ubuntu.com', 'cn.ubuntu.com',
-  'design.ubuntu.com', 'maas.io', 'canonical.com', 'landscape.canonical.com',
-  'pages.ubuntu.com', 'tutorials.ubuntu.com', 'docs.ubuntu.com']);
-  </script>
 
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
+  })(window,document,'script','dataLayer','GTM-WTCRZD7');</script>
   <!-- End Google Tag Manager -->
 
+  <link rel="stylesheet" href="/static/css/main.css">
+
+  <script src="/static/js/installversion.js" defer></script>
+  <script src="/static/js/osselector.js" defer></script>
+  <script src="/static/js/copytoclipboard.js" defer></script>
+</head>
+
+<body>
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ"
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WTCRZD7"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
 


### PR DESCRIPTION
## DONE

multipass has been running on the ubuntu.com GTM container, which is fine, just confusing.

Moving it to its own container with the same tracking.

## QA

1. Download this branch
2. Run the site
3. See that the new GTM is linked in - GTM-WTCRZD7 