### PR TITLE
Fix Python dependencies issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ FROM ubuntu:focal
 
 ADD . .
 # Install python and import python dependencies
-RUN apt-get update && apt-get install --no-install-recommends --yes python3-lib2to3 python3-pkg-resources ca-certificates libsodium-dev
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-setuptools python3-lib2to3 python3-pkg-resources ca-certificates libsodium-dev
 COPY --from=python-dependencies /root/.local/lib/python3.8/site-packages /root/.local/lib/python3.8/site-packages
 COPY --from=python-dependencies /root/.local/bin /root/.local/bin
 ENV PATH="/root/.local/bin:${PATH}"


### PR DESCRIPTION
## Done

Fix Python dependencies issue

## QA

- Pull the branch
- `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag test .`
- `docker run -ti -p "8026:80" --env SECRET_KEY=secret_key test`
