### PR TITLE
Use lastest-release.json to redirect to latest releases

### DIFF
--- a/templates/_layouts/default.html
+++ b/templates/_layouts/default.html
@@ -23,7 +23,6 @@
 
   <link rel="stylesheet" href="/static/css/main.css">
 
-  <!--script src="/static/js/installversion.js" defer></script-->
   <script src="/static/js/osselector.js" defer></script>
   <script src="/static/js/copytoclipboard.js" defer></script>
 </head>

--- a/templates/_layouts/default.html
+++ b/templates/_layouts/default.html
@@ -23,7 +23,7 @@
 
   <link rel="stylesheet" href="/static/css/main.css">
 
-  <script src="/static/js/installversion.js" defer></script>
+  <!--script src="/static/js/installversion.js" defer></script-->
   <script src="/static/js/osselector.js" defer></script>
   <script src="/static/js/copytoclipboard.js" defer></script>
 </head>

--- a/templates/index.html
+++ b/templates/index.html
@@ -82,7 +82,7 @@
   <div class="row">
     <div class="col-4">
       <img src="https://assets.ubuntu.com/v1/11ecbd2d-2018-logo-windows.svg" alt="Windows" />
-      <p><a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--neutral js-download" data-os="win-win">
+      <p><a href="/download/windows" class="p-button--neutral" data-os="win-win">
         <span class="p-link--external">Download Multipass for Windows</span>
       </a></p>
       <p>Windows 10 Pro/Enterprise v 1803 or later</p>
@@ -90,7 +90,7 @@
     </div>
     <div class="col-4">
       <img src="https://assets.ubuntu.com/v1/236f314d-macos.svg" alt="macOS" />
-      <p><a href="https://github.com/CanonicalLtd/multipass/releases" class="p-button--neutral js-download" data-os="mac">
+      <p><a href="/download/macos" class="p-button--neutral" data-os="mac">
         <span class="p-link--external">Download Multipass for macOS</span>
       </a></p>
       <p>Sierra 10.12.0 or later, 2010 or newer Mac</p>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,5 +1,6 @@
 # Packages
-from flask import render_template, request
+import os
+from flask import render_template, request, json, redirect
 import talisker.requests
 
 # Local
@@ -23,6 +24,17 @@ app = FlaskBase(
 @app.route("/")
 def index():
     return render_template("index.html")
+
+
+@app.route("/download/<osname>")
+def osredirect(osname):
+    if "macos" not in osname and "windows" not in osname:
+        return render_template("index.html")
+
+    SITE_ROOT = os.path.realpath(os.path.dirname(__file__))
+    json_url = os.path.join(SITE_ROOT, "../static/", "latest-release.json")
+    release = json.load(open(json_url))
+    return redirect(release["installer_urls"][osname], code=302)
 
 
 @app.after_request

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -29,11 +29,11 @@ def index():
 @app.route("/download/<osname>")
 def osredirect(osname):
     if "macos" not in osname and "windows" not in osname:
-        return render_template("index.html")
+        return redirect("/#install", code=301)
 
     SITE_ROOT = os.path.realpath(os.path.dirname(__file__))
-    json_url = os.path.join(SITE_ROOT, "../static/", "latest-release.json")
-    release = json.load(open(json_url))
+    json_path = os.path.join(SITE_ROOT, "../static/latest-release.json")
+    release = json.load(open(json_path))
     return redirect(release["installer_urls"][osname], code=302)
 
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -26,11 +26,8 @@ def index():
     return render_template("index.html")
 
 
-@app.route("/download/<osname>")
+@app.route("/download/<regex('windows|macos'):osname>")
 def osredirect(osname):
-    if osname not in ("windows", "macos"):
-        return redirect("/#install", code=301)
-
     SITE_ROOT = os.path.realpath(os.path.dirname(__file__))
     json_path = os.path.join(SITE_ROOT, "../static/latest-release.json")
     release = json.load(open(json_path))

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -28,7 +28,7 @@ def index():
 
 @app.route("/download/<osname>")
 def osredirect(osname):
-    if "macos" not in osname and "windows" not in osname:
+    if osname not in ("windows", "macos"):
         return redirect("/#install", code=301)
 
     SITE_ROOT = os.path.realpath(os.path.dirname(__file__))


### PR DESCRIPTION
## Done 

- Use lastest-release.json to redirect to latest releases via /download/<os> route

## QA

1. download this branch
2. go to http://0.0.0.0:8026/download/macos - see that it starts the latest macos download from github
3. go to http://0.0.0.0:8026/download/windows - see that it starts the latest windows download from github
4. go to http://0.0.0.0:8026/download/turkey and see that it loads the homepage (could change the URL in the browser too?) 