### PR TITLE
Integrate cookie-policy v3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "watch": "watch -p 'static/sass/**/*.scss' -c 'yarn run build'",
     "build": "yarn run build-css && yarn run build-js",
     "build-css": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --map false --use autoprefixer --replace 'static/css/**/*.css'",
-    "build-js": "mkdir -p static/js/modules && cp node_modules/@canonical/global-nav/dist/global-nav.js static/js/modules/",
+    "build-js": "yarn run copy-cookie-policy && yarn run copy-global-nav",
+    "copy-cookie-policy": "mkdir -p static/js/modules && cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js static/js/modules",
+    "copy-global-nav": "mkdir -p static/js/modules && cp node_modules/@canonical/global-nav/dist/global-nav.js static/js/modules",
     "format-python": "black --line-length 79 webapp",
     "lint-python": "flake8 webapp tests && black --check --line-length 79 webapp tests",
     "lint-scss": "stylelint static/**/*.scss",
@@ -17,6 +19,7 @@
   },
   "dependencies": {
     "@canonical/global-nav": "2.4.3",
+    "@canonical/cookie-policy": "3.0.4",
     "autoprefixer": "10.0.1",
     "node-sass": "4.14.1",
     "postcss": "8.1.1",

--- a/static/sass/main.scss
+++ b/static/sass/main.scss
@@ -1,2 +1,5 @@
 @import 'settings_colors';
 @import 'vanilla-framework/scss/build';
+
+// import cookie policy
+@import "@canonical/cookie-policy/build/css/cookie-policy";

--- a/templates/_layouts/default.html
+++ b/templates/_layouts/default.html
@@ -78,6 +78,9 @@
               </a>
             </li>
             <li class="p-inline-list__item">
+              <a class="js-revoke-cookie-manager" href="">Manage your tracker settings</a>
+            </li>
+            <li class="p-inline-list__item">
               <a
                 href="https://github.com/canonical/multipass/issues/new">
                 Report a bug on Multipass itself
@@ -100,7 +103,11 @@
   </footer>
 
   <script src="/static/js/modules/global-nav.js"></script>
-  <script>canonicalGlobalNav.createNav({maxWidth: '72rem'});</script>
+  <script src="/static/js/modules/cookie-policy.js"></script>
+  <script>
+    cpNs.cookiePolicy();
+    canonicalGlobalNav.createNav({maxWidth:"72rem"});
+  </script>
 </body>
 
 </html>

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,6 +191,11 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@canonical/cookie-policy@3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.4.tgz#c2d6d990dc0993344a9bf5c244374e3f51fe34f1"
+  integrity sha512-pI65cRFh9xU2xo3d9R8ifGbQoH72tk3p8xh/4ANuj9kREeh9G/gcim/iHQS7IffSocHT9l6ZtUXBcQ12m/CBMw==
+
 "@canonical/global-nav@2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.4.3.tgz#9d552bad1968537c4b952747b27d5d3db21cf327"


### PR DESCRIPTION
## Done
- Integrate cookie policy 3.0.4

## QA
- Pull the branch
- Run the site using the dotrun snap with `$ dotrun clean` then `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8026/
- Check the cookie policy appears
- Check the manager opens and works
- Make a selection and the notification should disappear
- Scroll to the footer and click the Manage link in the footer
- See that manager appears again. 

## Issue / Card
Fixes https://github.com/canonical-web-and-design/multipass.run/issues/118