### PR TITLE
Add embedded media to /multipass.run

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -48,6 +48,12 @@
    </div>
 </section>
 
+<section class="p-strip">
+  <div class="u-fixed-width u-align--center">
+    <script id="asciicast-394119" src="https://asciinema.org/a/394119.js?" async data-t="08" data-autoplay="true" data-speed="1.5"></script>
+  </div>
+</section>
+
 <section class="p-strip--suru-accent">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-6 u-align--center u-hide--small">


### PR DESCRIPTION
## Done

-  Add video to `multipass.run`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8026
- Check the video from the copy doc is visible. It should autoplay from 8s and be 1.5x the speed. 


## Issue / Card

Fixes #146 

## Screenshots

![image](https://user-images.githubusercontent.com/58959073/110774838-238a5a00-8256-11eb-818b-4836e515899c.png)
