### PR TITLE
Parse the docs linkchecker output for 400 errors

### DIFF
--- a/.github/workflows/docs-links.yaml
+++ b/.github/workflows/docs-links.yaml
@@ -2,11 +2,10 @@ name: docs links on multipass.run/docs
 
 on:
   schedule:
-    - cron: "0 13 * * 1"
+    - cron: "0 13 * * *"
 
 jobs:
   check-links:
-    if: github.repository == 'canonical-web-and-design/multipass.run'
     runs-on: ubuntu-latest
 
     steps:
@@ -16,9 +15,22 @@ jobs:
       - name: Install linkchecker
         run: sudo pip install LinkChecker
 
+      - name: Write linkchecker config file
+        run: |
+          mkdir -p ~/.linkchecker
+          cp scripts/linkcheckerrc ~/.linkchecker/
+
       - name: Run linkchecker
-        run: linkchecker --threads 2 --ignore-url "http://localhost*" --ignore-url "https://assets.ubuntu.com$" --check-extern --no-warnings https://multipass.run/docs
+        run: linkchecker https://multipass.run/docs > ~/.linkchecker/linkchecker-out.txt
+
+      - name: Parse linkchecker output
+        run: scripts/parseDocsLinkcheckerOutput
 
       - name: Send message on failure
         if: failure()
-        run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" ${{ secrets.BOT_URL }}?room=docs
+        run: |
+          curl -X POST \
+          -F "workflow=${GITHUB_WORKFLOW}" \
+          -F "repo_name=${GITHUB_REPOSITORY}" \
+          -F "action_id=${GITHUB_RUN_ID}" \
+          ${{ secrets.BOT_URL }}?room=docs

--- a/scripts/linkcheckerrc
+++ b/scripts/linkcheckerrc
@@ -1,0 +1,13 @@
+[checking]
+maxrequestspersecond=5
+
+[filtering]
+nofollow=!https:\/\/multipass\.run\/docs\/
+checkextern=1
+ignore=
+  https://assets\.ubuntu\.com
+  https://localhost\*
+
+[output]
+status=0
+warnings=0

--- a/scripts/parseDocsLinkcheckerOutput
+++ b/scripts/parseDocsLinkcheckerOutput
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if ! ls $HOME/.linkchecker/linkchecker-out.txt; then
+    echo "No linkchecker output found"
+    exit 1
+fi
+
+if grep -q "Error: 4" $HOME/.linkchecker/linkchecker-out.txt; then
+    cat $HOME/.linkchecker/linkchecker-out.txt
+    exit 1
+else
+    echo "No 400 errors were detected"
+    exit 0
+fi


### PR DESCRIPTION
## Done
- Move to using a linkcheckerrc
- Output the results into a file
- Parse the file for 400 errors

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4547