### PR TITLE
Update for a bugfix Multipass 1.8.1

### DIFF
--- a/static/latest-release.json
+++ b/static/latest-release.json
@@ -6,6 +6,6 @@
   "release_url": "https://github.com/canonical/multipass/releases/tag/v1.8.0",
   "installer_urls": {
     "windows": "https://github.com/canonical/multipass/releases/download/v1.8.0/multipass-1.8.0%2Bwin-win64.exe",
-    "macos": "https://github.com/canonical/multipass/releases/download/v1.8.0/multipass-1.8.0%2Bmac-Darwin.pkg"
+    "macos": "https://github.com/canonical/multipass/releases/download/v1.8.1/multipass-1.8.1%2Bmac-Darwin.pkg"
   }
 }


### PR DESCRIPTION
Changing only the url so that https://multipass.run/download/macos points at the bugfixed package.