### PR TITLE
Update pro tips pdf

### DIFF
--- a/templates/shared/forms/ubuntu-server-pro-tips.html
+++ b/templates/shared/forms/ubuntu-server-pro-tips.html
@@ -33,7 +33,7 @@
       <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335">
       <input type="hidden" name="Consent_to_Processing__c" value="yes" />
       <input type="hidden" aria-hidden="true" aria-label="hidden field" name="gclid" class="mktoField" id="gclid" value="" />
-      <input type="hidden" name="returnURL" value="https://assets.ubuntu.com/v1/f401c3f4-Ubuntu_Server_CLI_pro_tips_2020-04.pdf" aria-label="" />
+      <input type="hidden" name="returnURL" value="https://assets.ubuntu.com/v1/60e44ad3-Ubuntu.Server.CLI.pro.tips.19.04.22.pdf" aria-label="" />
     </form>
   </div>
 </div>


### PR DESCRIPTION
## Done
Update pro tips cheatsheet

## QA
Go to check https://multipass-run-245.demos.haus/ and scroll down to the "Download the cheatsheet"
 Fill up the form and download the new cheatsheet (old [cheatsheet](https://assets.ubuntu.com/v1/f401c3f4-Ubuntu_Server_CLI_pro_tips_2020-04.pdf))

## Issue
Fixes https://github.com/canonical-web-and-design/multipass.run/issues/235