### PR TITLE
Remove Freenode from the community section of the homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -110,7 +110,6 @@
     <div class="col-7">
       <h2>Join our community</h2>
       <p>Multipass is built by a team of engineers at Canonical and a community of contributors. We appreciate your interest in Multipass, and if you want to join the discussion or contribute, come and say hi. We don’t bite.</p>
-      <a href="https://webchat.freenode.net/?channels=#multipass" class="p-button">Freenode</a>
       <a href="https://github.com/canonical/multipass" class="p-button">GitHub</a>
       <a href="https://discourse.ubuntu.com/c/multipass/21" class="p-button">Discourse</a>
     </div>


### PR DESCRIPTION
## Done
Removed the link to Freenode at the bottom of the homepage

## QA
Check the link has been removed from the homepage

Fixes https://github.com/canonical-web-and-design/multipass.run/issues/262