### PR TITLE
Add redirect to the latest JSON file on canonical.com

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,0 +1,1 @@
+static/latest-release.json?: "https://canonical.com/static/files/latest-multipass-releases.json"


### PR DESCRIPTION
## Done

- Add redirect to the latest JSON file on canonical.com

## QA

- Go to /static/latest-release.json 
- Check it lands you on the same file on canonical.com